### PR TITLE
Fix Windows file encoding issues with Unicode characters

### DIFF
--- a/workflow_tools/contexts.py
+++ b/workflow_tools/contexts.py
@@ -169,12 +169,12 @@ class WorkflowContext:
     
     def save_to_file(self, filename: str = "workflow_context.json") -> None:
         """Save context to JSON file."""
-        with open(filename, 'w') as f:
+        with open(filename, 'w', encoding='utf-8') as f:
             json.dump(self.to_dict(), f, indent=2)
     
     @classmethod
     def load_from_file(cls, filename: str = "workflow_context.json") -> 'WorkflowContext':
         """Load context from JSON file."""
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf-8') as f:
             data = json.load(f)
         return cls.from_dict(data)

--- a/workflow_tools/core/config_loader.py
+++ b/workflow_tools/core/config_loader.py
@@ -184,7 +184,7 @@ class ConfigLoader:
             return {}
         
         try:
-            with open(file_path, 'r') as f:
+            with open(file_path, 'r', encoding='utf-8') as f:
                 return yaml.safe_load(f) or {}
         except yaml.YAMLError as e:
             print(f"Error parsing YAML file {filename}: {e}")

--- a/workflow_tools/phases/shared/cache_utils.py
+++ b/workflow_tools/phases/shared/cache_utils.py
@@ -1100,7 +1100,7 @@ class CacheUtils:
             
             # If there's an existing main.py, back it up
             if os.path.exists(main_py_path):
-                with open(main_py_path, 'r') as f:
+                with open(main_py_path, 'r', encoding='utf-8') as f:
                     existing_main = f.read()
                 
                 if existing_main != connection_test_code:
@@ -1110,13 +1110,13 @@ class CacheUtils:
                     printer.print(f"📋 Backed up existing main.py to main_final.py.backup")
             
             # Write the connection test code as main.py for testing
-            with open(main_py_path, 'w') as f:
+            with open(main_py_path, 'w', encoding='utf-8') as f:
                 f.write(connection_test_code)
             printer.print(f"✅ Connection test code written to main.py for testing")
             
             # Also save as connection_test.py for reference
             test_code_path = os.path.join(app_dir, "connection_test.py")
-            with open(test_code_path, 'w') as f:
+            with open(test_code_path, 'w', encoding='utf-8') as f:
                 f.write(connection_test_code)
             
             return True
@@ -1147,7 +1147,7 @@ class CacheUtils:
                 import shutil
                 shutil.copy2(main_py_backup_path, main_py_path)
                 
-                with open(main_py_path, 'r') as f:
+                with open(main_py_path, 'r', encoding='utf-8') as f:
                     restored_code = f.read()
                 
                 printer.print("✅ Restored final code from backup")

--- a/workflow_tools/phases/source/phase_source_connection_testing.py
+++ b/workflow_tools/phases/source/phase_source_connection_testing.py
@@ -403,7 +403,7 @@ class SourceConnectionTestingPhase(BasePhase):
                     self.context.code_generation.connection_test_code = debug_feedback
                     # Save the fixed code to file
                     test_code_path = os.path.join(self.context.code_generation.app_extract_dir, "connection_test.py")
-                    with open(test_code_path, 'w') as file:
+                    with open(test_code_path, 'w', encoding='utf-8') as file:
                         file.write(debug_feedback)
                     # If we're in auto-debug mode, the loop will call us again
                     # Just return False to trigger the next iteration
@@ -504,7 +504,7 @@ class SourceConnectionTestingPhase(BasePhase):
                     
                     # Save the fixed code
                     test_code_path = f"{app_dir}/main.py"
-                    with open(test_code_path, 'w') as file:
+                    with open(test_code_path, 'w', encoding='utf-8') as file:
                         file.write(fixed_code)
                     printer.print(f"📝 Fixed code saved to {test_code_path}")
                     
@@ -599,7 +599,7 @@ class SourceConnectionTestingPhase(BasePhase):
                     self.context.code_generation.connection_test_code = debug_feedback
                     # Save the fixed code to file
                     test_code_path = os.path.join(self.context.code_generation.app_extract_dir, "connection_test.py")
-                    with open(test_code_path, 'w') as file:
+                    with open(test_code_path, 'w', encoding='utf-8') as file:
                         file.write(debug_feedback)
                     # If we're in auto-debug mode, the loop will call us again
                     # Just return False to trigger the next iteration
@@ -723,7 +723,7 @@ class SourceConnectionTestingPhase(BasePhase):
             # Save sample data to temp directory
             sample_data_path = WorkingDirectory.get_temp_sample_path()
             
-            with open(sample_data_path, 'w') as file:
+            with open(sample_data_path, 'w', encoding='utf-8') as file:
                 tech_name = getattr(self.context.technology, 'source_technology', None) or self.context.technology.destination_technology
                 file.write(f"Source Technology: {tech_name}\n")
                 file.write(f"Sample Data Collected: {datetime.now()}\n")

--- a/workflow_tools/phases/source/phase_source_schema.py
+++ b/workflow_tools/phases/source/phase_source_schema.py
@@ -75,7 +75,7 @@ class SourceSchemaPhase(BasePhase):
                 return False
             
             # Read sample data
-            with open(self.context.sample_data_file, 'r') as file:
+            with open(self.context.sample_data_file, 'r', encoding='utf-8') as file:
                 sample_data = file.read()
             
             # Prepare prompt for schema analysis
@@ -166,7 +166,7 @@ Focus on providing actionable insights for code generation.
             
             os.makedirs("working_files", exist_ok=True)
             
-            with open(schema_file_path, 'w') as file:
+            with open(schema_file_path, 'w', encoding='utf-8') as file:
                 file.write(schema_doc)
             
             self.context.code_generation.source_schema_doc_path = schema_file_path
@@ -267,7 +267,7 @@ Focus on providing actionable insights for code generation.
             # Read sample data again if available
             sample_data = ""
             if hasattr(self.context, 'sample_data_file') and os.path.exists(self.context.sample_data_file):
-                with open(self.context.sample_data_file, 'r') as file:
+                with open(self.context.sample_data_file, 'r', encoding='utf-8') as file:
                     sample_data = file.read()
             
             # Prepare enhanced prompt with feedback

--- a/workflow_tools/services/claude_code_service.py
+++ b/workflow_tools/services/claude_code_service.py
@@ -113,7 +113,7 @@ class ClaudeCodeService:
         local_config_path = Path("config/local.yaml")
         if local_config_path.exists():
             try:
-                with open(local_config_path, 'r') as f:
+                with open(local_config_path, 'r', encoding='utf-8') as f:
                     local_config = yaml.safe_load(f) or {}
                     local_cli_path = local_config.get("claude_cli_path")
                     if local_cli_path:
@@ -390,7 +390,7 @@ class ClaudeCodeService:
             
             # Load existing local config or create new
             if local_config_path.exists():
-                with open(local_config_path, 'r') as f:
+                with open(local_config_path, 'r', encoding='utf-8') as f:
                     local_config = yaml.safe_load(f) or {}
             else:
                 local_config = {}
@@ -402,7 +402,7 @@ class ClaudeCodeService:
             local_config_path.parent.mkdir(parents=True, exist_ok=True)
             
             # Write local config
-            with open(local_config_path, 'w') as f:
+            with open(local_config_path, 'w', encoding='utf-8') as f:
                 yaml.dump(local_config, f, default_flow_style=False, sort_keys=False)
             
             printer.print(f"💾 Saved Claude CLI path to config/local.yaml (not in version control)")
@@ -773,14 +773,14 @@ class ClaudeCodeService:
                 from workflow_tools.core.working_directory import WorkingDirectory
                 schema_path = WorkingDirectory.get_cached_schema_path("sink", "schema_analysis")
                 try:
-                    with open(schema_path, "r") as f:
+                    with open(schema_path, "r", encoding='utf-8') as f:
                         schema_analysis = f.read()
                 except:
                     pass
         else:  # source
             if hasattr(self.context.code_generation, 'source_schema_doc_path'):
                 try:
-                    with open(self.context.code_generation.source_schema_doc_path, 'r') as f:
+                    with open(self.context.code_generation.source_schema_doc_path, 'r', encoding='utf-8') as f:
                         schema_analysis = f.read()
                 except:
                     pass

--- a/workflow_tools/services/file_manager.py
+++ b/workflow_tools/services/file_manager.py
@@ -125,7 +125,7 @@ CMD ["python", "main.py"]
         app_yaml_file = Path(code_dir) / "app.yaml"
         
         # Save as YAML (simplified format)
-        with open(app_yaml_file, 'w') as f:
+        with open(app_yaml_file, 'w', encoding='utf-8') as f:
             f.write("name: " + app_yaml["name"] + "\n")
             f.write("language: python\n")
             f.write("variables:\n")

--- a/workflow_tools/services/knowledge_gatherer.py
+++ b/workflow_tools/services/knowledge_gatherer.py
@@ -83,7 +83,7 @@ class KnowledgeGatheringService:
                         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                         schema_file_path = WorkingDirectory.get_cached_schema_path("source", f"source_schema_{timestamp}")
                         
-                        with open(schema_file_path, 'w') as file:
+                        with open(schema_file_path, 'w', encoding='utf-8') as file:
                             file.write(cached_schema)
                         
                         # Set the schema doc path in context (required for code generation)


### PR DESCRIPTION
## Summary
- Fixed 'charmap' codec errors when Claude generates code with Unicode characters (✓, emojis, etc.)
- Added UTF-8 encoding to all file read/write operations across the codebase

## Problem
Windows users were encountering this error when Klaus Kode tried to write generated code:
```
'charmap' codec can't encode character '\u2713' in position 2866: character maps to <undefined>
```

This occurred because Claude Code often includes Unicode characters (like ✓ checkmarks) in generated Python code, but Windows' default file encoding (cp1252) cannot handle these characters.

## Solution
Added `encoding='utf-8'` parameter to all `open()` calls for file operations in:
- `cache_utils.py` - Fixed all file operations for caching and backup
- `phase_source_connection_testing.py` - Fixed test code writes
- `phase_source_schema.py` - Fixed schema document writes
- `contexts.py` - Fixed context save/load operations
- `config_loader.py` - Fixed YAML config loading
- `file_manager.py` - Fixed app.yaml writes
- `knowledge_gatherer.py` - Fixed schema file writes
- `claude_code_service.py` - Fixed local config and schema reads

## Testing
Verified that files containing Unicode characters (like the checkmark ✓ in print statements) can now be written successfully on Windows systems.

## Related Issues
Fixes encoding issues reported by Windows users when working with Claude-generated code.