### PR TITLE
fix: add missing .claude/settings.json for directory restrictions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,40 @@
+{
+  "permissions": {
+    "deny": [
+      "Read(../**)",
+      "Write(../**)",
+      "Edit(../**)",
+      "MultiEdit(../**)",
+      "Read(/**)",
+      "Write(/**)",
+      "Edit(/**)",
+      "MultiEdit(/**)",
+      "Read(~/**)",
+      "Write(~/**)",
+      "Edit(~/**)",
+      "MultiEdit(~/**)",
+      "Bash(cd:../**)",
+      "Bash(cd:/**)",
+      "Bash(cd:~/**)"
+    ],
+    "allow": [
+      "Read(./**)",
+      "Write(./**)",
+      "Edit(./**)",
+      "MultiEdit(./**)",
+      "Glob(./**)",
+      "Grep(./**)",
+      "Bash(git:*)",
+      "Bash(python:*)",
+      "Bash(pip:*)",
+      "Bash(ls:*)",
+      "Bash(pwd:*)",
+      "Bash(echo:*)",
+      "Bash(mkdir:./**)",
+      "Bash(rm:./**)",
+      "Bash(cp:./**)",
+      "Bash(mv:./**)"
+    ]
+  },
+  "additionalDirectories": []
+}

--- a/.gitignore
+++ b/.gitignore
@@ -237,7 +237,10 @@ resources/template_requirements.txt
 manual_backups/
 logging/*
 claude_docs_archive/
-.claude
+# .claude/settings.json contains important project-specific Claude Code settings
+# Only ignore user-specific cache/tmp files
+.claude/cache/
+.claude/tmp/
 quix-ai-sidekick-sidepanel/
 
 # Navigation documentation (temporary analysis files)


### PR DESCRIPTION
- Remove .claude from .gitignore to allow tracking settings.json
- Add .claude/settings.json with rules to restrict Claude Code to repo boundaries
- Only ignore .claude/cache/ and .claude/tmp/ subdirectories

This ensures Claude Code SDK cannot access files outside the repository when running Klaus Kode, providing better security and preventing accidental access to sensitive system files.

🤖 Generated with [Claude Code](https://claude.ai/code)